### PR TITLE
feat: create sub-category + fix: verify if the subcategory exists in …

### DIFF
--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -92,7 +92,7 @@ export class CategoriesService {
 
   async verifySubCategories(category: CategoryDto): Promise<boolean> {
     const subCategories: SubCategories[] = await this.subCategoriesService.findAllWithoutFilters();
-    const subCategoriesIds: string[] = subCategories.map(subCategory => subCategory._id);
+    const subCategoriesIds: string[] = subCategories.map(subCategory => subCategory._id.toString());
     const invalidSubCategories: string[] = category.subCategories.filter(subCategory => !subCategoriesIds.includes(subCategory));
     return invalidSubCategories && invalidSubCategories.length ? false : true;
   }

--- a/src/sub-categories/dto/sub-categories.dto.ts
+++ b/src/sub-categories/dto/sub-categories.dto.ts
@@ -1,4 +1,4 @@
-import { ArrayMinSize, IsArray, IsBoolean, IsEmail, IsNotEmpty, IsNumber, IsNumberString, IsOptional, IsString, MaxLength, Min, MinLength } from "class-validator";
+import { ArrayMinSize, IsArray, IsBoolean, IsEmail, IsEmpty, IsNotEmpty, IsNumber, IsNumberString, IsOptional, IsString, MaxLength, Min, MinLength } from "class-validator";
 
 export class SubCategoryDto {
   @IsString()
@@ -13,9 +13,8 @@ export class SubCategoryDto {
   @IsOptional()
   description: string;
 
-  @IsString()
-  @IsNotEmpty()
-  creator_id: string;
+  @IsEmpty()
+  creatorId: string;
 
   @IsNumber()
   @IsOptional()

--- a/src/sub-categories/sub-categories.controller.ts
+++ b/src/sub-categories/sub-categories.controller.ts
@@ -1,4 +1,18 @@
-import { Controller } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Header, Headers, Post } from '@nestjs/common';
+import { SubCategoryDto } from './dto';
+import { SubCategoriesService } from './sub-categories.service';
 
-@Controller('v1/categories/:category_id/sub-categories')
-export class SubCategoriesController { }
+@Controller('v1/sub-categories')
+export class SubCategoriesController {
+
+  constructor(private readonly subCategoriesService: SubCategoriesService) { }
+
+  @Post()
+  async createSubCategory(@Body() body: SubCategoryDto, @Headers('user_id') userId: string) {
+    if (!userId || userId === '') {
+      throw new BadRequestException('Missing user_id header.');
+    }
+    body.creatorId = userId;
+    return await this.subCategoriesService.create(body);
+  }
+}

--- a/src/sub-categories/sub-categories.service.ts
+++ b/src/sub-categories/sub-categories.service.ts
@@ -1,11 +1,25 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { SubCategories } from '../schemas/subcategory.schema';
+import { SubCategoryDto } from './dto';
 
 @Injectable()
 export class SubCategoriesService {
   constructor(@InjectModel(SubCategories.name) private readonly subCategoriesModel: Model<SubCategories>) { }
+
+  async create(subCategory: SubCategoryDto): Promise<SubCategories> {
+    const existingCategories: SubCategoryDto[] = await this.subCategoriesModel.find({ name: { $regex: `^${subCategory.name}$`, $options: 'i' } });
+    if (existingCategories.length) {
+      throw new BadRequestException('Sub category name is too similar to existing sub categories');
+    }
+    try {
+      const createdSubCategory = new this.subCategoriesModel(subCategory);
+      return await createdSubCategory.save();
+    } catch (err) {
+      throw new BadRequestException(err.message);
+    }
+  }
 
   async findAllWithoutFilters(): Promise<SubCategories[]> {
     return await this.subCategoriesModel.find().exec();


### PR DESCRIPTION
This pull request includes significant changes to the `src/categories/categories.service.ts`, `src/sub-categories/dto/sub-categories.dto.ts`, `src/sub-categories/sub-categories.controller.ts`, and `src/sub-categories/sub-categories.service.ts` files. The changes primarily revolve around the handling of sub-categories and their validation in the application. 

Here are the most important changes:

Changes to `src/categories/categories.service.ts`:
* `verifySubCategories` method: The `subCategories.map` function now converts `_id` to a string before assigning it to `subCategoriesIds`. This change ensures that the `includes` function can correctly compare the `subCategory` ids.

Changes to `src/sub-categories/dto/sub-categories.dto.ts`:
* The `IsNotEmpty` import was replaced with `IsEmpty`, and the `creator_id` field was replaced with `creatorId` and its validation decorators were changed from `@IsString()` and `@IsNotEmpty()` to `@IsEmpty()`. This change implies that the `creatorId` should now be empty when creating a `SubCategoryDto` instance. [[1]](diffhunk://#diff-c9a312dda24643634525b018ed0d2f2751ab48eccca56fc35c40a4ce32e4e1faL1-R1) [[2]](diffhunk://#diff-c9a312dda24643634525b018ed0d2f2751ab48eccca56fc35c40a4ce32e4e1faL16-R17)

Changes to `src/sub-categories/sub-categories.controller.ts`:
* The `SubCategoriesController` class was significantly expanded. It now includes a constructor, a `createSubCategory` method, and new imports. The `createSubCategory` method creates a sub-category after validating the `user_id` header and assigning it to the `creatorId` field of the `SubCategoryDto` instance.

Changes to `src/sub-categories/sub-categories.service.ts`:
* A `create` method was added to the `SubCategoriesService` class. This method checks if a sub-category with a similar name already exists before creating a new one. If such a sub-category exists, it throws a `BadRequestException`.