### PR TITLE
feat: get sub-category by name or creator id + next and limit filters

### DIFF
--- a/src/sub-categories/sub-categories.controller.ts
+++ b/src/sub-categories/sub-categories.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Body, Controller, Header, Headers, Post } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Header, Headers, Post, Query } from '@nestjs/common';
 import { SubCategoryDto } from './dto';
 import { SubCategoriesService } from './sub-categories.service';
 
@@ -14,5 +14,16 @@ export class SubCategoriesController {
     }
     body.creatorId = userId;
     return await this.subCategoriesService.create(body);
+  }
+
+  @Get()
+  async findAllSubCategories(@Query('creator_id') creatorId: string, @Query('name') name: string, @Query('next') next: number, @Query('limit') limit: number) {
+    if (!limit) limit = 10;
+    if (!next) next = 1;
+    const subCategories = await this.subCategoriesService.findAll(creatorId, name, next, limit);
+    return {
+      subCategories,
+      next: Number(next) + 1
+    }
   }
 }

--- a/src/sub-categories/sub-categories.service.ts
+++ b/src/sub-categories/sub-categories.service.ts
@@ -21,6 +21,21 @@ export class SubCategoriesService {
     }
   }
 
+  async findAll(creatorId: string, name: string, next: number, limit: number): Promise<SubCategories[]> {
+    let subCategories: SubCategories[];
+    try {
+      if (creatorId) {
+        subCategories = await this.subCategoriesModel.find({ creatorId }).exec();
+      }
+      if (name) {
+        subCategories = await this.subCategoriesModel.find({ name: { $regex: `^${name}$`, $options: 'i' } }).exec();
+      }
+      return subCategories ? subCategories : await this.subCategoriesModel.find().limit(limit).skip((next - 1) * limit).exec();
+    } catch (err) {
+      throw new BadRequestException(err.message);
+    }
+  }
+
   async findAllWithoutFilters(): Promise<SubCategories[]> {
     return await this.subCategoriesModel.find().exec();
   }


### PR DESCRIPTION
This pull request primarily focuses on extending the functionality of the `SubCategories` module in our NestJS application. The changes allow for a more flexible retrieval of subcategories by introducing a new `findAllSubCategories` method in the `SubCategoriesController` and `SubCategoriesService`. This method accepts optional query parameters to filter the results by `creator_id` and `name`, and to paginate the results using `next` and `limit`.

Here are the key changes:

1. **Importing additional decorators in `SubCategoriesController`:**
   In `src/sub-categories/sub-categories.controller.ts`, the `Get` and `Query` decorators from `@nestjs/common` have been imported. These decorators are used to define a new GET endpoint and to extract query parameters from the request, respectively.

2. **Adding a new GET endpoint in `SubCategoriesController`:**
   A new `findAllSubCategories` method has been added to `SubCategoriesController`. This method is decorated with `@Get()`, making it a GET endpoint. It accepts four optional query parameters: `creator_id`, `name`, `next`, and `limit`. The method retrieves subcategories based on these parameters and returns them along with the next page number.

3. **Adding a new method in `SubCategoriesService`:**
   A new `findAll` method has been added to `SubCategoriesService` in `src/sub-categories/sub-categories.service.ts`. This method accepts four parameters: `creatorId`, `name`, `next`, and `limit`. Depending on the provided parameters, it fetches subcategories either by `creatorId`, by `name` (case-insensitive exact match), or all subcategories paginated by `next` and `limit`. If an error occurs during the database operation, it throws a `BadRequestException` with the error message.