### PR TITLE
feat: delete sub-category by _id

### DIFF
--- a/src/sub-categories/sub-categories.controller.ts
+++ b/src/sub-categories/sub-categories.controller.ts
@@ -1,5 +1,10 @@
+<<<<<<< Updated upstream
 import { BadRequestException, Body, Controller, Get, Header, Headers, Post, Query } from '@nestjs/common';
 import { SubCategoryDto } from './dto';
+=======
+import { BadRequestException, Body, Controller, Delete, Get, Header, Headers, HttpCode, Param, Patch, Post, Query } from '@nestjs/common';
+import { SubCategoryDto, SubCategoryPatchDto } from './dto';
+>>>>>>> Stashed changes
 import { SubCategoriesService } from './sub-categories.service';
 
 @Controller('v1/sub-categories')
@@ -26,4 +31,18 @@ export class SubCategoriesController {
       next: Number(next) + 1
     }
   }
+<<<<<<< Updated upstream
+=======
+
+  @Patch(':id')
+  async updateSubCategory(@Param('id') id: string, @Body() body: SubCategoryPatchDto) {
+    return await this.subCategoriesService.updateSubCategory(id, body);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  async deleteSubCategory(@Param('id') id: string) {
+    return await this.subCategoriesService.deleteSubCategory(id);
+  }
+>>>>>>> Stashed changes
 }

--- a/src/sub-categories/sub-categories.service.ts
+++ b/src/sub-categories/sub-categories.service.ts
@@ -36,6 +36,43 @@ export class SubCategoriesService {
     }
   }
 
+<<<<<<< Updated upstream
+=======
+
+  async updateSubCategory(id: string, subCategory: SubCategoryPatchDto) {
+    const existingCategories: SubCategoryPatchDto[] = await this.subCategoriesModel.find({ name: { $regex: `^${subCategory.name}$`, $options: 'i' } });
+    if (existingCategories.length) {
+      throw new BadRequestException('Sub categories name is too similar to existing categories');
+    }
+
+    if (subCategory.name) {
+      subCategory.name = subCategory.name.toLowerCase();
+    }
+
+    var subCategoryUpdated: SubCategories
+
+    try {
+      subCategoryUpdated = await this.subCategoriesModel.findOneAndUpdate({ _id: id }, subCategory, { new: true })
+    } catch (err) {
+      if (err.name === 'CastError') {
+        throw new BadRequestException('Invalid id')
+      }
+      throw new InternalServerErrorException(err.message)
+    }
+    if (!subCategoryUpdated)
+      throw new NotFoundException('Category not found')
+    subCategoryUpdated.updatedAt = new Date()
+    return subCategoryUpdated
+  }
+
+  async deleteSubCategory(id: string) {
+    try {
+      await this.subCategoriesModel.findByIdAndDelete(id).exec();
+    } catch (err) {
+    }
+  }
+
+>>>>>>> Stashed changes
   async findAllWithoutFilters(): Promise<SubCategories[]> {
     return await this.subCategoriesModel.find().exec();
   }


### PR DESCRIPTION
This pull request includes changes to the `src/sub-categories/sub-categories.controller.ts` and `src/sub-categories/sub-categories.service.ts` files to add a delete function for subcategories. The most important changes include importing the `Delete` and `HttpCode` decorators from `@nestjs/common` in the controller file, adding a new `deleteSubCategory` method to the `SubCategoriesController` class, and implementing the `deleteSubCategory` method in the `SubCategoriesService` class.

Changes to `src/sub-categories/sub-categories.controller.ts`:

* Imported `Delete` and `HttpCode` decorators from `@nestjs/common` to support the HTTP DELETE operation.
* Added a new `deleteSubCategory` method to the `SubCategoriesController` class. This method uses the `Delete` decorator to handle HTTP DELETE requests and the `HttpCode` decorator to return a 204 status code. The method calls the `deleteSubCategory` method of the `SubCategoriesService` class.

Changes to `src/sub-categories/sub-categories.service.ts`:

* Implemented the `deleteSubCategory` method in the `SubCategoriesService` class. This method attempts to delete a subcategory with a given ID from the database.